### PR TITLE
automate default permission 'basic' insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Dependencies Status](http://jarkeeper.com/JarrodCTaylor/authenticated-compojure-api/status.png)](http://jarkeeper.com/JarrodCTaylor/authenticated-compojure-api)
 
 An example compojure-api application demonstrating everything you need for
-token based authentication using buddy.
+token-based authentication using Buddy.
 
 ## Usage
 
@@ -21,7 +21,52 @@ the file like so:
  :test-env-vars {:env {:database-url  "postgres://auth_user:password1@127.0.0.1:5432/auth_test?stringtype=unspecified"
                        :auth-key      "theSecretKeyUsedToCreateAndReadTokens"}}}
 ```
-## Create the Postgres database for local dev
+Equivalent environment variables are `DATABASE_URL`, `USER_EMAIL`, `USER_PASS_KEY`, `AUTH_KEY`.
+
+## Create the PostgreSQL database for local development
+
+`psql < script/init_database.sql`
+
+You can run the same script on remote servers -- see psql documentation.
+
+
+### Running Locally
+
+`lein run -m authenticated-compojure-api.server 3000`
+
+### Table migrations / creation
+
+When you start the server any needed tables will be created automatically.
+
+See "Manual Setup" below if you see errors about missing tables (especially on old DB servers).
+
+You will now be able to create new users.
+
+### Running Tests
+
+`lein test`
+
+### Documentation
+
+The HTML documentation can be viewed online at [authenticated-compojure-api](http://www.jarrodctaylor.com/authenticated-compojure-api/)
+or generated locally with `lein doc` the output will be saved in `doc/api`.
+
+### Manual Database setup
+
+If you have an old version of PostgreSQL (8.4 or earlier), you may want to do this manually.
+
+##### Permissions
+
+When you start the server any needed tables will be created automatically.
+Starting out you may need to create a `basic` permission in the permissions
+table.
+
+``` sql
+INSERT INTO permission (permission)
+VALUES ('basic');
+```
+
+##### Table Creation
 
 ``` sql
 CREATE DATABASE auth;
@@ -35,29 +80,3 @@ ALTER ROLE auth_user WITH PASSWORD 'password1';
 GRANT ALL PRIVILEGES ON DATABASE auth to auth_user;
 GRANT ALL PRIVILEGES ON DATABASE auth_test to auth_user;
 ```
-
-### Running Locally
-
-`lein run -m authenticated-compojure-api.server 3000`
-
-### Add the required permission
-
-When you start the server any needed tables will be created automatically.
-Starting out you will need to create a `basic` permission in the permissions
-table.
-
-``` sql
-INSERT INTO permission (permission)
-VALUES ('basic');
-```
-
-You will now be able to create new users.
-
-### Running Tests
-
-`lein test`
-
-### Documentation
-
-The HTML documentation can be viewed online at [authenticated-compojure-api](http://www.jarrodctaylor.com/authenticated-compojure-api/)
-or generated locally with `lein doc` the output will be saved in `doc/api`.

--- a/src/authenticated_compojure_api/server.clj
+++ b/src/authenticated_compojure_api/server.clj
@@ -8,6 +8,7 @@
   []
   (query/create-registered-user-table-if-not-exists!)
   (query/create-permission-table-if-not-exists!)
+  (query/create-basic-permission-if-not-exists!)
   (query/create-user-permission-table-if-not-exists!)
   (query/create-password-reset-key-table-if-not-exists!))
 

--- a/src/authenticated_compojure_api/tables/user/permission.sql
+++ b/src/authenticated_compojure_api/tables/user/permission.sql
@@ -7,3 +7,9 @@ CREATE TABLE IF NOT EXISTS permission (
 -- name: drop-permission-table!
 -- drop the permission table
 DROP TABLE permission;
+
+-- name: create-basic-permission-if-not-exists!
+-- create the 'basic' permission if it does not exist
+INSERT INTO permission (permission)
+ SELECT 'basic'
+ WHERE NOT EXISTS (SELECT 1 FROM permission WHERE permission='basic');


### PR DESCRIPTION
Fixes #12 -- added an `INSERT IF NOT EXISTS` sort of structure following the table creation pattern.