### PR TITLE
Updates dependencies, fixes tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,21 +4,21 @@
             :url "https://opensource.org/licenses/MIT"}
 
   :dependencies [[org.clojure/clojure        "1.8.0"]
-                 [metosin/compojure-api      "1.1.2"]
-                 [metosin/ring-http-response "0.6.5"]
+                 [metosin/compojure-api      "1.1.3"]
+                 [metosin/ring-http-response "0.7.0"]
                  [metosin/ring-swagger-ui    "2.1.4-0"]
-                 [cheshire                   "5.6.1"]
+                 [cheshire                   "5.6.2"]
                  [http-kit                   "2.1.19"]
-                 [buddy                      "0.13.0"]
+                 [buddy                      "1.0.0"]
                  [org.clojure/java.jdbc      "0.6.1"]
                  [postgresql/postgresql      "9.3-1102.jdbc41"]
                  [com.layerware/hugsql       "0.4.7"]
                  [environ                    "1.0.3"]
-                 [clj-time                   "0.11.0"]
+                 [clj-time                   "0.12.0"]
                  [com.draines/postal         "2.0.0"]]
 
-  :plugins      [[lein-environ "1.0.2"]
-                 [funcool/codeina "0.3.0" :exclusions [org.clojure/clojure]]]
+  :plugins      [[lein-environ "1.0.3"]
+                 [funcool/codeina "0.4.0" :exclusions [org.clojure/clojure]]]
 
   :min-lein-version  "2.5.0"
 

--- a/src/authenticated_compojure_api/general_functions/user/create_token.clj
+++ b/src/authenticated_compojure_api/general_functions/user/create_token.clj
@@ -1,7 +1,7 @@
 (ns authenticated-compojure-api.general-functions.user.create-token
    (:require [environ.core :refer [env]]
              [clj-time.core :as time]
-             [buddy.sign.jws :as jws]))
+             [buddy.sign.jwt :as jwt]))
 
 (defn create-token
   "Create a signed json web token. The token contents are; username, email, id,
@@ -12,4 +12,4 @@
                            (update-in [:email] str)
                            (assoc     :exp (time/plus (time/now) (time/seconds 900))))
         token-contents (select-keys stringify-user [:permissions :username :email :id :exp])]
-    (jws/sign token-contents (env :auth-key) {:alg :hs512})))
+    (jwt/sign token-contents (env :auth-key) {:alg :hs512})))

--- a/test/authenticated_compojure_api/auth/credential_retrieval_tests.clj
+++ b/test/authenticated_compojure_api/auth/credential_retrieval_tests.clj
@@ -4,7 +4,7 @@
             [authenticated-compojure-api.handler :refer :all]
             [authenticated-compojure-api.test-utils :as helper]
             [authenticated-compojure-api.queries.query-defs :as query]
-            [buddy.sign.jws :as jws]
+            [buddy.sign.jwt :as jwt]
             [ring.mock.request :as mock]))
 
 (defn setup-teardown [f]
@@ -23,7 +23,7 @@
                                   (helper/basic-auth-header "Everyman:pass")))
           body           (helper/parse-body (:body response))
           id             (:id body)
-          token-contents (jws/unsign (:token body) (env :auth-key) {:alg :hs512})]
+          token-contents (jwt/unsign (:token body) (env :auth-key) {:alg :hs512})]
       (is (= 5           (count body)))
       (is (= 200         (:status response)))
       (is (= "Everyman"  (:username body)))
@@ -42,7 +42,7 @@
                                   (helper/basic-auth-header "e@man.com:pass")))
           body           (helper/parse-body (:body response))
           id             (:id body)
-          token-contents (jws/unsign (:token body) (env :auth-key) {:alg :hs512})]
+          token-contents (jwt/unsign (:token body) (env :auth-key) {:alg :hs512})]
       (is (= 5           (count body)))
       (is (= 200         (:status response)))
       (is (= "Everyman"  (:username body)))
@@ -66,7 +66,7 @@
       (is (= 200              (:status response)))
       (is (= "JarrodCTaylor"  (:username body)))
       (is (= 36               (count (:refreshToken body))))
-      (is (= "basic,admin"    (:permissions (jws/unsign (:token body) (env :auth-key) {:alg :hs512})))))))
+      (is (= "basic,admin"    (:permissions (jwt/unsign (:token body) (env :auth-key) {:alg :hs512})))))))
 
 (deftest invlid-password-does-not-return-auth-credentials
   (testing "Invalid password does not return auth credentials"
@@ -100,7 +100,7 @@
           refresh-token      (:refreshToken initial-body)
           refreshed-response (app (mock/request :get (str "/api/refresh-token/" refresh-token)))
           body               (helper/parse-body (:body refreshed-response))
-          token-contents     (jws/unsign (:token body) (env :auth-key) {:alg :hs512})]
+          token-contents     (jwt/unsign (:token body) (env :auth-key) {:alg :hs512})]
       (is (= 200              (:status refreshed-response)))
       (is (= 2                (count body)))
       (is (= true             (contains? body :token)))


### PR DESCRIPTION
Buddy-sign now uses `jwt/sign` for signing JSON based tokens. More information [here](https://funcool.github.io/buddy-sign/latest/#signing-data). 